### PR TITLE
Add backers and sponsors from Open Collective

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Subrion CMS
 
 [![Join the chat at https://gitter.im/intelliants/subrion](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/intelliants/subrion?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![OpenCollective](https://opencollective.com/subrion/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/subrion/sponsors/badge.svg)](#sponsors)
+
 
 
 ## What is Subrion?
@@ -27,6 +30,77 @@ What you mainly want to know is that:
 * It's very well appreciated, and highly suggested, to start a new feature whenever you want to make changes or add new functionality. It will make it much easier for us to just checkout your feature branch and test it, before merging it into `develop`
 
 Please read [Contribution Guidelines](CONTRIBUTING.md)
+
+## Backers
+
+Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/subrion#backer)]
+
+<a href="https://opencollective.com/subrion/backer/0/website" target="_blank"><img src="https://opencollective.com/subrion/backer/0/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/1/website" target="_blank"><img src="https://opencollective.com/subrion/backer/1/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/2/website" target="_blank"><img src="https://opencollective.com/subrion/backer/2/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/3/website" target="_blank"><img src="https://opencollective.com/subrion/backer/3/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/4/website" target="_blank"><img src="https://opencollective.com/subrion/backer/4/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/5/website" target="_blank"><img src="https://opencollective.com/subrion/backer/5/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/6/website" target="_blank"><img src="https://opencollective.com/subrion/backer/6/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/7/website" target="_blank"><img src="https://opencollective.com/subrion/backer/7/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/8/website" target="_blank"><img src="https://opencollective.com/subrion/backer/8/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/9/website" target="_blank"><img src="https://opencollective.com/subrion/backer/9/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/10/website" target="_blank"><img src="https://opencollective.com/subrion/backer/10/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/11/website" target="_blank"><img src="https://opencollective.com/subrion/backer/11/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/12/website" target="_blank"><img src="https://opencollective.com/subrion/backer/12/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/13/website" target="_blank"><img src="https://opencollective.com/subrion/backer/13/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/14/website" target="_blank"><img src="https://opencollective.com/subrion/backer/14/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/15/website" target="_blank"><img src="https://opencollective.com/subrion/backer/15/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/16/website" target="_blank"><img src="https://opencollective.com/subrion/backer/16/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/17/website" target="_blank"><img src="https://opencollective.com/subrion/backer/17/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/18/website" target="_blank"><img src="https://opencollective.com/subrion/backer/18/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/19/website" target="_blank"><img src="https://opencollective.com/subrion/backer/19/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/20/website" target="_blank"><img src="https://opencollective.com/subrion/backer/20/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/21/website" target="_blank"><img src="https://opencollective.com/subrion/backer/21/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/22/website" target="_blank"><img src="https://opencollective.com/subrion/backer/22/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/23/website" target="_blank"><img src="https://opencollective.com/subrion/backer/23/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/24/website" target="_blank"><img src="https://opencollective.com/subrion/backer/24/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/25/website" target="_blank"><img src="https://opencollective.com/subrion/backer/25/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/26/website" target="_blank"><img src="https://opencollective.com/subrion/backer/26/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/27/website" target="_blank"><img src="https://opencollective.com/subrion/backer/27/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/28/website" target="_blank"><img src="https://opencollective.com/subrion/backer/28/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/backer/29/website" target="_blank"><img src="https://opencollective.com/subrion/backer/29/avatar.svg"></a>
+
+
+## Sponsors
+
+Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/subrion#sponsor)]
+
+<a href="https://opencollective.com/subrion/sponsor/0/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/1/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/2/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/3/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/4/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/5/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/6/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/7/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/8/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/9/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/9/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/10/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/10/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/11/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/11/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/12/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/12/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/13/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/13/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/14/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/14/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/15/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/15/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/16/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/16/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/17/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/17/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/18/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/18/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/19/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/19/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/20/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/20/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/21/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/21/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/22/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/22/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/23/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/23/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/24/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/24/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/25/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/25/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/26/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/26/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/27/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/27/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/28/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/28/avatar.svg"></a>
+<a href="https://opencollective.com/subrion/sponsor/29/website" target="_blank"><img src="https://opencollective.com/subrion/sponsor/29/avatar.svg"></a>
 
 ## Copyright
 


### PR DESCRIPTION
Now your open collective backers and sponsors can to appear directly on your README. 
see how it'll look [here](https://github.com/apex/apex#backers)
[More info](https://github.com/opencollective/opencollective/wiki/Github-banner)
Also add badges on top.