### PR TITLE
Core will apply default length for text fields if attribute is not set

### DIFF
--- a/admin/fields.php
+++ b/admin/fields.php
@@ -249,8 +249,6 @@ class iaBackendController extends iaAbstractControllerBackend
         if ($fieldTypes['values'] && !in_array($entry['type'], $fieldTypes['values'])) {
             $this->addMessage('field_type_invalid');
         } else {
-            empty($entry['length']) && $entry['length'] = iaField::DEFAULT_LENGTH;
-
             switch ($entry['type']) {
                 case iaField::TEXT:
                     $entry['length'] = min(255, max(1, $data['text_length']));

--- a/includes/classes/ia.admin.module.php
+++ b/includes/classes/ia.admin.module.php
@@ -2052,20 +2052,32 @@ class iaModule extends abstractCore
             $className = $entry['class_name'];
             $parents = $entry['parent'];
 
-            if (iaField::TREE == $entry['type']) {
-                $entry['timepicker'] = $entry['multiselection'];
-            } elseif (iaField::IMAGE == $entry['type'] || iaField::PICTURES == $entry['type']) {
-                if ($entry['timepicker'] = (bool)$imageTypes) {
-                    $entry['imagetype_primary'] = isset($imageTypes[1]) ? $imageTypes[1] : $imageTypes[0];
-                    $entry['imagetype_thumbnail'] = $imageTypes[0];
-                } else {
-                    $entry['imagetype_primary'] = iaField::IMAGE_TYPE_LARGE;
-                    $entry['imagetype_thumbnail'] = iaField::IMAGE_TYPE_THUMBNAIL;
-                }
+            switch ($entry['type']) {
+                case iaField::TREE:
+                    $entry['timepicker'] = $entry['multiselection'];
 
-                if (iaField::IMAGE == $entry['type'] && !$entry['length']) {
-                    $entry['length'] = 1;
-                }
+                    break;
+
+                case iaField::IMAGE:
+                case iaField::PICTURES:
+                    if ($entry['timepicker'] = (bool)$imageTypes) {
+                        $entry['imagetype_primary'] = isset($imageTypes[1]) ? $imageTypes[1] : $imageTypes[0];
+                        $entry['imagetype_thumbnail'] = $imageTypes[0];
+                    } else {
+                        $entry['imagetype_primary'] = iaField::IMAGE_TYPE_LARGE;
+                        $entry['imagetype_thumbnail'] = iaField::IMAGE_TYPE_THUMBNAIL;
+                    }
+
+                    if (iaField::IMAGE == $entry['type'] && !$entry['length']) {
+                        $entry['length'] = 1;
+                    }
+
+                    break;
+
+                case iaField::TEXT:
+                    if (!$entry['length']) {
+                        $entry['length'] = iaField::DEFAULT_LENGTH;
+                    }
             }
 
             unset($entry['item_pages'], $entry['table_name'], $entry['class_name'], $entry['parent'],


### PR DESCRIPTION
'length' attribute maybe empty in install.xml file. I'm introducing code that will set default length for text fields in such case.