### PR TITLE
Fixed bug in email templates when using smarty functions

### DIFF
--- a/admin/templates/default/email-templates.tpl
+++ b/admin/templates/default/email-templates.tpl
@@ -84,14 +84,14 @@
                     <div class="translate-group" id="language-group-body">
                         <div class="translate-group__default">
                             <div class="translate-group__item">
-                                {ia_wysiwyg name="body_{$core.masterLanguage.iso}" source=true}
+                                {ia_wysiwyg name="body_{$core.masterLanguage.iso}" source=true entities=false basicEntities=false}
                                 {if count($core.languages) > 1}<div class="translate-group__item__code">{$core.masterLanguage.title|escape}</div>{/if}
                         </div>
                         <div class="translate-group__langs">
                             {foreach $core.languages as $iso => $language}
                                 {if $iso != $core.masterLanguage.iso}
                                 <div class="translate-group__item">
-                                    {ia_wysiwyg name="body_{$iso}" source=true}
+                                    {ia_wysiwyg name="body_{$iso}" source=true entities=false basicEntities=false}
                                     <span class="translate-group__item__code">{$language.title|escape}</span>
                                 </div>
                                 {/if}

--- a/includes/classes/ia.core.smarty.php
+++ b/includes/classes/ia.core.smarty.php
@@ -163,6 +163,12 @@ class iaSmarty extends Smarty
         if (isset($params['source'])) {
             $options['startupMode'] = 'source';
         }
+        if (isset($params['entities'])) {
+            $options['entities'] = $params['entities'];
+        }
+        if (isset($params['basicEntities'])) {
+            $options['basicEntities'] = 'basicEntities';
+        }
         $options = json_encode($options);
 
         $iaView = iaCore::instance()->iaView;


### PR DESCRIPTION
Fixed bug in email templates when using smarty functions by adding two optional parameters(entities and basicEntities) in smarty function ia_wysiwyg