### PR TITLE
Solution for #721

### DIFF
--- a/includes/classes/ia.core.cache.php
+++ b/includes/classes/ia.core.cache.php
@@ -54,11 +54,13 @@ class iaCache extends abstractUtil
      * @param string $fileName cache file name to get data from
      * @param int $seconds number of seconds until file is considered old
      * @param bool $isObject true - return an object, false - return an array
+     * @param bool $isMultilingual flag for multilingual cache
      *
      * @return bool|mixed|string
      */
-    public function get($fileName, $seconds = 0, $isObject = false)
+    public function get($fileName, $seconds = 0, $isObject = false, $isMultilingual = false)
     {
+        $fileName .= ($isMultilingual ? '_' . $this->iaCore->iaView->language : '');
         $this->_setFileName($fileName);
 
         if (!$this->_cachingEnabled || !is_file($this->_filePath)) {
@@ -71,7 +73,7 @@ class iaCache extends abstractUtil
             if (isset($_SERVER['REQUEST_TIME']) && filemtime($this->_filePath) > ($_SERVER['REQUEST_TIME'] - $seconds)) {
                 $return = $this->_read();
             } else {
-                $this->remove($fileName);
+                $this->remove($fileName, $isMultilingual);
 
                 return false;
             }
@@ -88,10 +90,11 @@ class iaCache extends abstractUtil
      *
      * @param string $fileName file name to write data to (may be encrypted)
      * @param string $Data data to be written
+     * @param bool $isMultilingual flag for multilingual cache
      *
      * @return bool
      */
-    public function write($fileName, $Data)
+    public function write($fileName, $Data, $isMultilingual = false)
     {
         if (!$this->_cachingEnabled) {
             return true;
@@ -100,6 +103,7 @@ class iaCache extends abstractUtil
             $Data = serialize($Data);
         }
 
+        $fileName .= ($isMultilingual ? '_' . $this->iaCore->iaView->language : '');
         $this->_setFileName($fileName);
 
         if (!$file = fopen($this->_filePath, 'wb')) {
@@ -126,11 +130,13 @@ class iaCache extends abstractUtil
      * Delete cache file from the cache directory
      *
      * @param string $fileName file name to be deleted
+     * @param bool $isMultilingual flag for multilingual cache
      *
      * @return bool
      */
-    public function remove($fileName)
+    public function remove($fileName, $isMultilingual = false)
     {
+        $fileName .= ($isMultilingual ? '_' . $this->iaCore->iaView->language : '');
         $this->_setFileName($fileName);
 
         $iaView = &$this->iaCore->iaView;

--- a/includes/classes/ia.core.php
+++ b/includes/classes/ia.core.php
@@ -373,9 +373,8 @@ final class iaCore
     public function getConfig($reloadRequired = false)
     {
         if (empty($this->config) || $reloadRequired) {
-            $key = 'config_' . $this->iaView->language;
-
-            $this->config = $this->iaCache->get($key, 604800, true);
+            $key = 'config';
+            $this->config = $this->iaCache->get($key, 604800, true, true);
             iaSystem::renderTime('config', 'Cached Configuration Loaded');
 
             if (empty($this->config) || $reloadRequired) {
@@ -388,7 +387,7 @@ final class iaCore
                 $this->config['module'] = $extras;
                 $this->config['block_positions'] = $this->iaView->positions;
 
-                $this->iaCache->write($key, $this->config);
+                $this->iaCache->write($key, $this->config, true);
                 iaSystem::renderTime('config', 'Configuration written to cache file');
             }
 

--- a/includes/classes/ia.front.search.php
+++ b/includes/classes/ia.front.search.php
@@ -883,13 +883,13 @@ SQL;
             return [];
         }
 
-        $key = 'filter_tree_' . md5($packedNodes) . '_' . $this->iaView->language;
+        $key = 'filter_tree_' . md5($packedNodes);
 
-        if ($result = $this->iaCore->iaCache->get($key, 25920000, true)) { // 30 days
+        if ($result = $this->iaCore->iaCache->get($key, 25920000, true, true)) { // 30 days
             return $result;
         } else {
             $result = $this->_parseTreeNodes($itemName, $fieldName, $packedNodes, $this->iaView->language);
-            $this->iaCore->iaCache->write($key, $result);
+            $this->iaCore->iaCache->write($key, $result, true);
 
             return $result;
         }


### PR DESCRIPTION
1. I've added `isMultilingual` flag for cache write/get/remove methods so it can be now specified:
whether the data to be cached is multilingual or not.

Pros of this solution: separate files created for only multilingual cache data
Cons: we should update some code in packages/plugins to use this feature

2. Another solution would be to update `iaCache` class so it will generate separate cache files for each data
i.e the structure would look something like: 

![image](https://user-images.githubusercontent.com/7892851/42159181-a5b345a8-7e14-11e8-9c08-7fe0fd7aba70.png)

Pros: no need to update any plugins or packages, it will work perfectly.
Cons: duplicate cache files with the same content.

If the current 1st solution is OK, then please approve this PR
if not, then I'll push according changes

Thanks.