### PR TITLE
Resolves #777

### DIFF
--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -8,7 +8,7 @@
 Options -ExecCGI
 
 # Deny files access for some file extensions
-<FilesMatch "(?i)\.(php|php5|php4|php3|php2|phtml|pl|py|jsp|asp|htm|html|shtml|sh|cgi)$">
+<FilesMatch "(?i)\.(php|php5|php4|php3|php2|phtml|pl|py|jsp|asp|htm|html|shtml|sh|cgi|svg)$">
     ForceType text/plain
     Order Deny,Allow
     Deny from All


### PR DESCRIPTION
This PR includes minor change in `.htaccess` file which forbids access for `.svg` files which could contain XSS payload.
We do not support SVG type images for Single Image Upload & Multiple Images Upload fields, so the only way to upload an SVG file to Subrion CMS is through Upload Attachment field.