### PR TITLE
Resolves #739 & 735

### DIFF
--- a/admin/currencies.php
+++ b/admin/currencies.php
@@ -120,9 +120,7 @@ class iaBackendController extends iaAbstractControllerBackend
 
     protected function _entryUpdate(array $entryData, $entryId)
     {
-        $this->_iaDb->update($entryData, iaDb::convertIds($entryId, 'code'));
-
-        return (0 === $this->_iaDb->getErrorNumber());
+        return $this->_iaDb->update($entryData, iaDb::convertIds($entryId, 'code'));
     }
 
     protected function _setDefaultValues(array &$entry)

--- a/admin/email-templates.php
+++ b/admin/email-templates.php
@@ -78,8 +78,8 @@ class iaBackendController extends iaAbstractControllerBackend
 
     protected function _gridUpdate($params)
     {
-        $this->_iaDb->update($params, iaDb::convertIds($params['name'], 'name'));
+        $result = $this->_iaDb->update($params, iaDb::convertIds($params['name'], 'name'));
 
-        return ['result' => (0 == $this->_iaDb->getErrorNumber())];
+        return ['result' => $result];
     }
 }

--- a/admin/hooks.php
+++ b/admin/hooks.php
@@ -45,9 +45,9 @@ class iaBackendController extends iaAbstractControllerBackend
                 break;
 
             case 'set':
-                $this->_iaDb->update(['code' => $_POST['code']], iaDb::convertIds($_POST['id']));
+                $result = $this->_iaDb->update(['code' => $_POST['code']], iaDb::convertIds($_POST['id']));
 
-                $output['result'] = (0 == $this->_iaDb->getErrorNumber());
+                $output['result'] = $result;
                 $output['message'] = iaLanguage::get($output['result'] ? 'saved' : 'db_error');
                 break;
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -46,9 +46,8 @@ class iaBackendController extends iaAbstractControllerBackend
 
         if (isset($_GET['reset']) || isset($_GET['save'])) {
             $data = isset($_GET['list']) ? $_GET['list'] : '';
-            if ($iaDb->update(['admin_columns' => $data], iaDb::convertIds(iaUsers::getIdentity()->id), null,
-                iaUsers::getTable())
-            ) {
+            if ($iaDb->update(['admin_columns' => $data],
+                iaDb::convertIds(iaUsers::getIdentity()->id), null, iaUsers::getTable())) {
                 iaUsers::reloadIdentity();
             }
 

--- a/admin/languages.php
+++ b/admin/languages.php
@@ -233,7 +233,7 @@ class iaBackendController extends iaAbstractControllerBackend
         if (isset($stmt)) {
             $output['result'] = isset($insertion)
                 ? $insertion
-                : (bool)$this->_iaDb->update($params, $stmt);
+                : $this->_iaDb->update($params, $stmt);
             $output['message'] = iaLanguage::get($output['result'] ? $this->_phraseEditSuccess : $this->_phraseSaveError);
 
             empty($output['result']) || $this->getHelper()->createJsCache(true);
@@ -356,9 +356,7 @@ class iaBackendController extends iaAbstractControllerBackend
 
     protected function _entryUpdate(array $entryData, $entryId)
     {
-        $this->_iaDb->update($entryData, iaDb::convertIds($entryId), null, iaLanguage::getLanguagesTable());
-
-        return (0 === $this->_iaDb->getErrorNumber());
+        return $this->_iaDb->update($entryData, iaDb::convertIds($entryId), null, iaLanguage::getLanguagesTable());
     }
 
     protected function _entryDelete($entryId)

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -406,7 +406,7 @@ class iaBackendController extends iaAbstractControllerBackend
     {
         $status = $deactivate ? iaCore::STATUS_INACTIVE : iaCore::STATUS_ACTIVE;
 
-        return (bool)$this->_iaDb->update(['status' => $status], iaDb::convertIds($moduleName, 'name'));
+        return $this->_iaDb->update(['status' => $status], iaDb::convertIds($moduleName, 'name'));
     }
 
     private function _reset($domain)

--- a/front/actions.php
+++ b/front/actions.php
@@ -77,9 +77,8 @@ if (iaView::REQUEST_JSON == $iaView->getRequestType() && isset($_POST['action'])
                         }
 
                         $newValue = is_array($value) ? serialize($pictures) : implode(',', $pictures);
-                        $iaDb->update([$field => $newValue], iaDb::convertIds($itemId), null, $tableName);
 
-                        if (0 == $iaDb->getErrorNumber()) {
+                        if ($iaDb->update([$field => $newValue], iaDb::convertIds($itemId), null, $tableName)) {
                             $output['error'] = false;
                             unset($output['message']);
                         } else {

--- a/front/profile.php
+++ b/front/profile.php
@@ -82,9 +82,7 @@ if (iaView::REQUEST_HTML == $iaView->getRequestType()) {
                     $item['usergroup_id'] = $_POST['usergroup_id'];
                 }
 
-                $iaDb->update($item, iaDb::convertIds(iaUsers::getIdentity()->id));
-
-                if (0 == $iaDb->getErrorNumber()) {
+                if ($iaDb->update($item, iaDb::convertIds(iaUsers::getIdentity()->id))) {
                     $iaCore->startHook('phpUserProfileUpdate', ['userInfo' => iaUsers::getIdentity(true), 'data' => $item]);
                     iaUsers::reloadIdentity();
 

--- a/includes/api/auth.php
+++ b/includes/api/auth.php
@@ -166,9 +166,7 @@ class iaApiAuth extends abstractCore
             'session' => session_id()
         ];
 
-        $this->iaDb->insert($entry, null, self::getTable());
-
-        if ($this->iaDb->getErrorNumber() > 0) {
+        if (!$this->iaDb->insert($entry, null, self::getTable())) {
             throw new Exception('Unable to issue a token', iaApiResponse::INTERNAL_ERROR);
         }
 

--- a/includes/api/entity/abstract.php
+++ b/includes/api/entity/abstract.php
@@ -120,9 +120,7 @@ abstract class iaApiEntityAbstract extends abstractCore
 
         $this->_apiProcessFields($data);
 
-        $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
-
-        return (0 == $this->iaDb->getErrorNumber());
+        return $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
     }
 
     public function apiInsert($data)
@@ -216,9 +214,9 @@ abstract class iaApiEntityAbstract extends abstractCore
                 $this->iaCore->factory('field')->deleteFilesByFieldName($fieldName, $this->getName(), $value);
             }
 
-            $this->iaDb->update([$fieldName => ''], iaDb::convertIds($entryId), null, self::getTable());
+            $result = $this->iaDb->update([$fieldName => ''], iaDb::convertIds($entryId), null, self::getTable());
 
-            if (0 !== $this->iaDb->getErrorNumber()) {
+            if (!$result) {
                 throw new Exception('DB error', iaApiResponse::INTERNAL_ERROR);
             }
         }
@@ -265,9 +263,9 @@ abstract class iaApiEntityAbstract extends abstractCore
                 $value = $content;
         }
 
-        $this->iaDb->update([$fieldName => $value], iaDb::convertIds($entryId), null, self::getTable());
+        $result = $this->iaDb->update([$fieldName => $value], iaDb::convertIds($entryId), null, self::getTable());
 
-        if (0 !== $this->iaDb->getErrorNumber()) {
+        if (!$result) {
             throw new Exception('DB error', iaApiResponse::INTERNAL_ERROR);
         }
 

--- a/includes/api/entity/field.php
+++ b/includes/api/entity/field.php
@@ -62,9 +62,7 @@ class iaApiEntityField extends iaApiEntityAbstract
             throw new Exception(iaLanguage::get(iaView::ERROR_FORBIDDEN), iaApiResponse::FORBIDDEN);
         }
 
-        $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
-
-        return (0 == $this->iaDb->getErrorNumber());
+        return $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
     }
 
     public function apiDelete($id, array $params)

--- a/includes/api/entity/member.php
+++ b/includes/api/entity/member.php
@@ -106,9 +106,7 @@ class iaApiEntityMember extends iaApiEntityAbstract
             }
         }
 
-        $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
-
-        $result = (0 === $this->iaDb->getErrorNumber());
+        $result = $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
 
         if ($id == iaUsers::getIdentity()->id && $result) {
             iaUsers::reloadIdentity();

--- a/includes/classes/ia.admin.block.php
+++ b/includes/classes/ia.admin.block.php
@@ -128,8 +128,8 @@ class iaBlock extends abstractCore
             unset($itemData['name']);
         }
 
-        $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
-        $result = (0 == $this->iaDb->getErrorNumber());
+        $result = $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
+
         if ($result) {
             $this->_saveBundle($id, $itemData, $bundle);
 

--- a/includes/classes/ia.admin.module.php
+++ b/includes/classes/ia.admin.module.php
@@ -585,8 +585,7 @@ class iaModule extends abstractCore
                 if ($id = $iaDb->one_bind(iaDb::ID_COLUMN_SELECTION, '`name` = :name AND `item` = :item', $entry)) {
                     unset($entry['name'], $entry['item']);
 
-                    $iaDb->update($entry, iaDb::convertIds($id));
-                    $result = (0 == $iaDb->getErrorNumber());
+                    $result = $iaDb->update($entry, iaDb::convertIds($id));
                 } else {
                     $result = $iaDb->insert($entry);
                 }
@@ -2393,9 +2392,7 @@ class iaModule extends abstractCore
 
             $entryData = $this->iaDb->row('`id`, `' . implode('`,`', array_keys($entry)) . '`', $stmt, $tableName);
 
-            $this->iaDb->update($entry, $stmt, null, $tableName);
-
-            if (0 === $this->iaDb->getErrorNumber()) {
+            if ($this->iaDb->update($entry, $stmt, null, $tableName)) {
                 if ('field' != $type && isset($entry['sticky'])) {
                     $this->iaCore->factory('block')->setVisibility($entryData['id'], $entry['sticky'], $pages);
                 }

--- a/includes/classes/ia.base.controller.admin.php
+++ b/includes/classes/ia.base.controller.admin.php
@@ -547,9 +547,7 @@ abstract class iaAbstractControllerBackend
 
     protected function _entryUpdate(array $entryData, $entryId)
     {
-        $this->_iaDb->update($entryData, iaDb::convertIds($entryId));
-
-        return (0 === $this->_iaDb->getErrorNumber());
+        return $this->_iaDb->update($entryData, iaDb::convertIds($entryId));
     }
 
     protected function _reopen($option, $action)

--- a/includes/classes/ia.base.db.php
+++ b/includes/classes/ia.base.db.php
@@ -324,7 +324,7 @@ interface iaInterfaceDbAdapter
     public function insert(array $values, $rawValues = null, $tableName = null);
 
     /**
-     * Updates a record in a table and returns a number of affected rows
+     * Updates a record in a table and returns a boolean result
      *
      * Ex:  the code below updates a record in 'table_name'
      * 		$iaCore->iaDb->update(array('id' => '50', 'title' => 'My Row Title', 'text' => 'My Row Text'), null, array('date' => 'NOW()'), 'table_name');
@@ -337,7 +337,7 @@ interface iaInterfaceDbAdapter
      * @param array|null $rawValues key=>value array for the record without sanitizing, commonly used for date insert
      * @param string|null $tableName table name to perform update, null uses current set table
      *
-     * @return bool|int
+     * @return bool
      */
     public function update($values, $condition = null, $rawValues = null, $tableName = null);
 

--- a/includes/classes/ia.base.item.admin.php
+++ b/includes/classes/ia.base.item.admin.php
@@ -91,9 +91,7 @@ class itemModelAdmin extends abstractCore
             return false;
         }
 
-        $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
-
-        $result = (0 === $this->iaDb->getErrorNumber());
+        $result = $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
 
         if ($result) {
             $this->_writeLog(iaCore::ACTION_EDIT, $itemData, $id);

--- a/includes/classes/ia.base.item.front.php
+++ b/includes/classes/ia.base.item.front.php
@@ -112,7 +112,7 @@ class itemModelFront extends abstractCore
         }
 
         $currentData = $this->iaDb->row(iaDb::ALL_COLUMNS_SELECTION, iaDb::convertIds($id), self::getTable());
-        $result = (bool)$this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
+        $result = $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
 
         if ($result) {
             $this->updateCounters($id, $itemData, iaCore::ACTION_EDIT, $currentData);

--- a/includes/classes/ia.base.module.admin.php
+++ b/includes/classes/ia.base.module.admin.php
@@ -213,9 +213,7 @@ abstract class abstractModuleAdmin extends abstractCore
             return false;
         }
 
-        $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
-
-        $result = (0 === $this->iaDb->getErrorNumber());
+        $result = $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
 
         if ($result) {
             $this->_writeLog(iaCore::ACTION_EDIT, $itemData, $id);

--- a/includes/classes/ia.base.module.front.api.php
+++ b/includes/classes/ia.base.module.front.api.php
@@ -110,9 +110,7 @@ abstract class abstractModuleFrontApiResponder extends abstractModuleFront
 
         $this->_apiProcessFields($data);
 
-        $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
-
-        return (0 == $this->iaDb->getErrorNumber());
+        return $this->iaDb->update($data, iaDb::convertIds($id), null, $this->getTable());
     }
 
     public function apiInsert($data)
@@ -212,9 +210,9 @@ abstract class abstractModuleFrontApiResponder extends abstractModuleFront
                 $this->iaCore->factory('field')->deleteFilesByFieldName($fieldName, $this->getItemName(), $value);
             }
 
-            $this->iaDb->update([$fieldName => ''], iaDb::convertIds($entryId), null, self::getTable());
+            $result = $this->iaDb->update([$fieldName => ''], iaDb::convertIds($entryId), null, self::getTable());
 
-            if (0 !== $this->iaDb->getErrorNumber()) {
+            if (!$result) {
                 throw new Exception('DB error', iaApiResponse::INTERNAL_ERROR);
             }
         }
@@ -261,9 +259,9 @@ abstract class abstractModuleFrontApiResponder extends abstractModuleFront
                 $value = $content;
         }
 
-        $this->iaDb->update([$fieldName => $value], iaDb::convertIds($entryId), null, self::getTable());
+        $result = $this->iaDb->update([$fieldName => $value], iaDb::convertIds($entryId), null, self::getTable());
 
-        if (0 !== $this->iaDb->getErrorNumber()) {
+        if (!$result) {
             throw new Exception('DB error', iaApiResponse::INTERNAL_ERROR);
         }
 

--- a/includes/classes/ia.base.module.front.php
+++ b/includes/classes/ia.base.module.front.php
@@ -159,7 +159,7 @@ abstract class abstractModuleFront extends abstractCore
         }
 
         $currentData = $this->iaDb->row(iaDb::ALL_COLUMNS_SELECTION, iaDb::convertIds($id), self::getTable());
-        $result = (bool)$this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
+        $result = $this->iaDb->update($itemData, iaDb::convertIds($id), null, self::getTable());
 
         if ($result) {
             $this->updateCounters($id, $itemData, iaCore::ACTION_EDIT, $currentData);
@@ -224,7 +224,7 @@ abstract class abstractModuleFront extends abstractCore
         }
 
         $this->iaDb->insert(['item' => $itemName, 'item_id' => $itemId, 'ip' => $ipAddress, 'date' => $date], null, $viewsTable);
-        $result = $this->iaDb->update(null, iaDb::convertIds($itemId), [$columnName => '`' . $columnName . '` + 1'], self::getTable());
+        $result = $this->iaDb->update(null, iaDb::convertIds($itemId), [$columnName => '`' . $columnName . '` + 1'], self::getTable()); // t
 
         return (bool)$result;
     }

--- a/includes/classes/ia.core.acl.php
+++ b/includes/classes/ia.core.acl.php
@@ -411,7 +411,15 @@ class iaAcl extends abstractUtil
         }
 
         return $row
-            ? (bool)$iaDb->update(['access' => (int)$access], $stmt, null, $this->_dbTablePrivileges)
-            : (bool)$iaDb->insert(['object' => $object, 'object_id' => $objectId, 'type' => $type, 'type_id' => (int)$typeId, 'action' => $action, 'access' => (int)$access, 'module' => $extras], null, $this->_dbTablePrivileges);
+            ? $iaDb->update(['access' => (int)$access], $stmt, null, $this->_dbTablePrivileges)
+            : (bool)$iaDb->insert([
+                'object' => $object,
+                'object_id' => $objectId,
+                'type' => $type,
+                'type_id' => (int)$typeId,
+                'action' => $action,
+                'access' => (int)$access,
+                'module' => $extras
+            ], null, $this->_dbTablePrivileges);
     }
 }

--- a/includes/classes/ia.core.config.php
+++ b/includes/classes/ia.core.config.php
@@ -108,9 +108,7 @@ class iaConfig extends abstractCore
     {
         $maxOrder = $this->iaDb->getMaxOrder(self::getConfigGroupsTable());
 
-        $this->iaDb->insert($data, ['order' => ++$maxOrder], self::getConfigGroupsTable());
-
-        return 0 === $this->iaDb->getErrorNumber();
+        return (bool)$this->iaDb->insert($data, ['order' => ++$maxOrder], self::getConfigGroupsTable());
     }
 
     public function deleteGroup($key, $value)
@@ -227,7 +225,7 @@ SQL;
                 : implode(',', $value);
         }
 
-        return (bool)$this->iaDb->update(['value' => $value], iaDb::convertIds($key, self::KEY_COLUMN), null, self::getTable());
+        return $this->iaDb->update(['value' => $value], iaDb::convertIds($key, self::KEY_COLUMN), null, self::getTable());
     }
 
     public function saveCustom($data, $key, $value, $type, $typeId)

--- a/includes/classes/ia.core.cron.php
+++ b/includes/classes/ia.core.cron.php
@@ -69,7 +69,10 @@ class iaCron extends abstractCore
         if (is_file(IA_HOME . $data[self::C_CMD])) {
             $nextLaunchTs = self::_getLastScheduledRunTime($data);
 
-            if ($this->iaDb->update(['date_next_launch' => $nextLaunchTs], iaDb::convertIds($job['id']), ['date_prev_launch' => 'UNIX_TIMESTAMP()'])) {
+            $result = $this->iaDb->update(['date_next_launch' => $nextLaunchTs],
+                iaDb::convertIds($job['id']), ['date_prev_launch' => 'UNIX_TIMESTAMP()']);
+
+            if ($result) {
                 $this->_launchFile($data[self::C_CMD]);
             }
         } else {

--- a/includes/classes/ia.core.invoice.php
+++ b/includes/classes/ia.core.invoice.php
@@ -150,7 +150,7 @@ SQL;
             'country' => $address['country']
         ];
 
-        return (bool)$this->iaDb->update($values, iaDb::convertIds($transactionId, 'transaction_id'), null, self::getTable());
+        return $this->iaDb->update($values, iaDb::convertIds($transactionId, 'transaction_id'), null, self::getTable());
     }
 
     public function deleteCorrespondingInvoice($transactionId)

--- a/includes/classes/ia.core.mysqli.php
+++ b/includes/classes/ia.core.mysqli.php
@@ -618,9 +618,7 @@ class iaDb extends abstractUtil implements iaInterfaceDbAdapter
 
         $table = $tableName ? $this->prefix . $tableName : $this->_table;
 
-        $this->query(sprintf('UPDATE `%s` SET %s %s', $table, $stmtSet, $stmtWhere));
-
-        return $this->getAffected();
+        return $this->query(sprintf('UPDATE `%s` SET %s %s', $table, $stmtSet, $stmtWhere));
     }
 
     public function delete($condition, $tableName = null, $values = [])

--- a/includes/classes/ia.core.transaction.php
+++ b/includes/classes/ia.core.transaction.php
@@ -102,7 +102,7 @@ class iaTransaction extends abstractCore
             $transactionData['date_updated'] = date(iaDb::DATETIME_FORMAT);
             !(self::PASSED == $transactionData['status'] && self::PASSED != $transaction['status'])
                     || $transactionData['date_paid'] = date(iaDb::DATETIME_FORMAT);
-            $result = (bool)$this->iaDb->update($transactionData, iaDb::convertIds($id), null, self::getTable());
+            $result = $this->iaDb->update($transactionData, iaDb::convertIds($id), null, self::getTable());
 
             if ($result && isset($transactionData['status'])) {
                 $operation = empty($transactionData['item']) ? $transaction['item'] : $transactionData['item'];
@@ -112,9 +112,11 @@ class iaTransaction extends abstractCore
                     $amount = empty($transactionData['amount']) ? $transaction['amount'] : $transactionData['amount'];
 
                     if (self::PASSED == $transactionData['status'] && self::PASSED != $transaction['status']) {
-                        $result = (bool)$this->iaDb->update(null, iaDb::convertIds($itemId), ['funds' => '`funds` + ' . $amount], iaUsers::getTable());
+                        $result = $this->iaDb->update(null, iaDb::convertIds($itemId), [
+                            'funds' => '`funds` + ' . $amount], iaUsers::getTable());
                     } elseif (self::PASSED != $transactionData['status'] && self::PASSED == $transaction['status']) {
-                        $result = (bool)$this->iaDb->update(null, iaDb::convertIds($itemId), ['funds' => '`funds` - ' . $amount], iaUsers::getTable());
+                        $result = $this->iaDb->update(null, iaDb::convertIds($itemId), [
+                            'funds' => '`funds` - ' . $amount], iaUsers::getTable());
                     }
                 }
 
@@ -142,7 +144,8 @@ class iaTransaction extends abstractCore
     {
         $result = false;
         if ($transactionId) {
-            $result = (bool)$this->iaDb->delete('`id` = :id AND `status` != :status', self::getTable(), ['id' => (int)$transactionId, 'status' => self::PASSED]);
+            $result = (bool)$this->iaDb->delete('`id` = :id AND `status` != :status', self::getTable(),
+                ['id' => (int)$transactionId, 'status' => self::PASSED]);
             empty($result) || $this->iaCore->factory('invoice')->deleteCorrespondingInvoice($transactionId);
         }
 

--- a/includes/classes/ia.core.users.php
+++ b/includes/classes/ia.core.users.php
@@ -560,7 +560,7 @@ SQL;
         $stmt = '`email` = :email AND `sec_key` = :key';
         $this->iaDb->bind($stmt, ['email' => $email, 'key' => $key]);
 
-        $result = (bool)$this->iaDb->update(['sec_key' => '', 'status' => $status], $stmt,
+        $result = $this->iaDb->update(['sec_key' => '', 'status' => $status], $stmt,
             ['date_update' => iaDb::FUNCTION_NOW], self::getTable());
         if ($result) {
             $member = $this->iaDb->row(iaDb::ALL_COLUMNS_SELECTION, iaDb::convertIds($email, 'email'), self::getTable());


### PR DESCRIPTION
This PR is a fix for #739 and #735.

For the issue description please return to #739 
With this PR `$iaDb->update()` calls return boolean value.  
The whole codebase was checked for usages of `iaDb::update` and none of them use `affected rows` value. I did a brief scanning of the modules and was not able to find `iaDb::update` usage that would rely on its return value (affected rows). Anyway, if there are any such use cases, those would be updated for the upcoming release.

Now in order to check if data was updated in the db simply check:
```
if ($iaDb->update(...)) { ... }
```
No need for boolean castings & call for a function `getErrorNumber()`