### PR TITLE
Feature/866

### DIFF
--- a/admin/visual.php
+++ b/admin/visual.php
@@ -31,12 +31,39 @@ class iaBackendController extends iaAbstractControllerBackend
     protected $_processAdd = false;
     protected $_processEdit = false;
 
+    private $defaultOutput = [];
+
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->defaultOutput = ['result' => false, 'message' => iaLanguage::get('invalid_parameters')];
+    }
+
+    private function handleInlineBlockEdit($name, $data)
+    {
+        if (!iaValidate::isAlphaNumericValid($name)) {
+            return $this->defaultOutput;
+        }
+
+//        $this->_iaDb->update();
+
+        return [
+            'result' => true,
+            'message' => iaLanguage::get('saved'),
+        ];
+    }
 
     protected function _jsonAction()
     {
         $this->_iaCore->factory('validate');
 
         $output = ['result' => false, 'message' => iaLanguage::get('invalid_parameters')];
+
+        if (isset($_POST['action']) && 'save-inline' == $_POST['action']) {
+            return $this->handleInlineBlockEdit($_POST['name'], $_POST['data']);
+        }
 
         if (isset($_POST['action']) && 'save' == $_POST['action']) {
             $type = $_POST['type'];

--- a/includes/classes/ia.core.smarty.php
+++ b/includes/classes/ia.core.smarty.php
@@ -155,7 +155,7 @@ class iaSmarty extends Smarty
     public function getManagablePhrase($key, $text)
     {
         $blockTags = '<p|<h1|<h2|<h3|<h4|<h5|<h6|<ol|<ul|<pre|<address|<blockquote|<dl|<div|<fieldset|<form|<hr|<noscript|<table';
-        $id = microtime() . $key;
+        $id = mt_rand(0, 9999999) . $key;
         $wrapperTag = 'span';
         $isHtml = true;
 

--- a/includes/classes/ia.core.smarty.php
+++ b/includes/classes/ia.core.smarty.php
@@ -169,10 +169,10 @@ class iaSmarty extends Smarty
 <$wrapperTag class="box-visual">
     <$wrapperTag class="box-visual__content" id="$id">$text</$wrapperTag>
     <span class="box-visual__actions">
-        <a class="js-phrase-inline-edit box-visual__actions__item box-visual__actions__item--edit"
-           data-type="phrase" data-key="$key" href="#" data-action="edit" data-is_html="$isHtml">
+        <span class="js-phrase-inline-edit box-visual__actions__item box-visual__actions__item--edit"
+           data-type="phrase" data-key="$key" data-action="edit" data-is_html="$isHtml">
             <span class="v-icon v-icon--pencil"></span>
-        </a>
+        </span>
     </span>
 </$wrapperTag>
 HTML;

--- a/includes/classes/ia.core.smarty.php
+++ b/includes/classes/ia.core.smarty.php
@@ -687,6 +687,7 @@ class iaSmarty extends Smarty
             $smarty->assign('style', isset($params['style']) ? $params['style'] : '');
             $smarty->assign('title', isset($params['title']) ? $params['title'] : '');
             $smarty->assign('ismenu', isset($params['ismenu']) ? $params['ismenu'] : false);
+            $smarty->assign('type', isset($params['type']) ? $params['type'] : false);
             $smarty->assign('_block_content_', $content);
 
             if (empty($params['tpl'])) {

--- a/includes/classes/ia.core.smarty.php
+++ b/includes/classes/ia.core.smarty.php
@@ -135,7 +135,20 @@ class iaSmarty extends Smarty
             return iaLanguage::getf($key, $params);
         }
 
-        return iaLanguage::get($key, $default);
+        $phrase = iaLanguage::get($key, $default);
+
+//assign an id to the phrase: mktime() . $key
+
+        if (iaCore::instance()->iaView->manageMode) {
+            if (strip_tags($phrase) !== $phrase) { // if string contains any tags
+                $tags = '<p,<h1,<h2,<h3,<h4,<h5,<h6,<ol,<ul,<pre,<address,<blockquote,<dl,<div,<fieldset,<form,<hr,<noscript,<table';
+
+            } else {
+
+            }
+        }
+
+        return $phrase;
     }
 
     public static function ia_page_url($params)

--- a/js/visual/js/visual.js
+++ b/js/visual/js/visual.js
@@ -105,9 +105,41 @@ $(function () {
                 var editor = CKEDITOR['instances']['content_' + blockName]
                 var data = isHtml ? editor.getData() : editor.element.getText()
 
-                saveBlockInline(blockId, data);
+                saveInlineEdit('block', blockId, data);
 
                 $block.removeAttr('contenteditable')
+                editor.destroy()
+                break;
+        }
+    });
+
+    $('.js-page-inline-edit').on('click', function (e) {
+        e.preventDefault();
+
+        var $this = $(this),
+            pageName = $this.data('name'),
+            pageId = 'page-content__' + pageName,
+            $page = $('#' + pageId)
+
+        switch ($this.data('action')) {
+            case 'edit':
+                $this.data('action', 'save')
+                $this.find('.v-icon').removeClass('v-icon--pencil').addClass('v-icon--check-circle-o')
+                $page.attr('contenteditable', true)
+
+                var config = { startupFocus: true };
+
+                CKEDITOR.inline(pageId, config)
+                break;
+
+            case 'save':
+                $this.data('action', 'edit')
+                $this.find('.v-icon').removeClass('v-icon--check-circle-o').addClass('v-icon--pencil')
+                var editor = CKEDITOR['instances'][pageId]
+
+                saveInlineEdit('page', pageName, editor.getData());
+
+                $page.removeAttr('contenteditable')
                 editor.destroy()
                 break;
         }
@@ -133,9 +165,10 @@ $(function () {
     });
 });
 
-function saveBlockInline(id, data) {
+function saveInlineEdit(type, id, data) {
     intelli.post(intelli.visualModeUrl, {
         action: 'save-inline',
+        type: type,
         id: id,
         data: data
     }, function (res) {

--- a/js/visual/js/visual.js
+++ b/js/visual/js/visual.js
@@ -53,7 +53,7 @@ $(function () {
         var $this = $(this),
             id = $this.attr('id').substring(6),
             moveBtn = ($this.parent('.groupWrapper').hasClass('groupWrapper--movable')) ? '<div class="box-visual__actions__item box-visual__actions__item--move"><span class="v-icon v-icon--arrows"></span></div>' : '',
-            editBtn = (-1 !== ['html', 'plain'].indexOf($this.data('type'))) ? '<a class="js-block-inline-edit box-visual__actions__item box-visual__actions__item--edit" data-type="blocks" data-name="' + id + '" href="#" data-action="edit"><span class="v-icon v-icon--pencil"></span></a>' : '',
+            editBtn = (-1 !== ['html', 'plain'].indexOf($this.data('type'))) ? '<a class="js-block-inline-edit box-visual__actions__item box-visual__actions__item--edit" data-type="blocks" data-name="' + id + '" data-id="' + $this.data('block_id') + '" href="#" data-action="edit"><span class="v-icon v-icon--pencil"></span></a>' : '',
             hiddenClass = (1 == $this.attr('vm-hidden')) ? ' box-visual--hidden' : '';
 
         $this.addClass('box-visual ' + hiddenClass).append(
@@ -80,7 +80,8 @@ $(function () {
 
         var $this = $(this),
             $block = $this.closest('.box-visual').find('.box__content'),
-            blockName = $this.data('name')
+            blockName = $this.data('name'),
+            blockId = $this.data('id');
 
         switch ($this.data('action')) {
             case 'edit':
@@ -95,7 +96,7 @@ $(function () {
                 $this.find('.v-icon').removeClass('v-icon--check-circle-o').addClass('v-icon--pencil')
                 var editor = CKEDITOR['instances']['content_' + blockName]
 
-                saveBlockInline(blockName, editor.getData());
+                saveBlockInline(blockId, editor.getData());
 
                 $block.removeAttr('contenteditable')
                 editor.destroy()
@@ -123,10 +124,10 @@ $(function () {
     });
 });
 
-function saveBlockInline(blockName, data) {
+function saveBlockInline(id, data) {
     intelli.post(intelli.visualModeUrl, {
         action: 'save-inline',
-        name: blockName,
+        id: id,
         data: data
     }, function (res) {
         intelli.notifFloatBox({msg: res.message, type: res.result ? 'success' : 'error', autohide: true});

--- a/js/visual/js/visual.js
+++ b/js/visual/js/visual.js
@@ -90,7 +90,7 @@ $(function () {
                 $this.find('.v-icon').removeClass('v-icon--pencil').addClass('v-icon--check-circle-o')
                 $block.attr('contenteditable', true)
 
-                var config = { startupFocus: true };
+                var config = { startupFocus: true, floatSpaceDockedOffsetY: 35 };
 
                 if (!isHtml) {
                     config['removeButtons'] = 'PasteFromWord,Paste,Bold,Italic,Underline,Strike,TextColor,Format,BGColor,Link,Image,Iframe,Unlink,Youtube,Embed'

--- a/js/visual/js/visual.js
+++ b/js/visual/js/visual.js
@@ -89,7 +89,14 @@ $(function () {
                 $this.data('action', 'save')
                 $this.find('.v-icon').removeClass('v-icon--pencil').addClass('v-icon--check-circle-o')
                 $block.attr('contenteditable', true)
-                CKEDITOR.inline($block.get(0), { startupFocus: true })
+
+                var config = { startupFocus: true };
+
+                if (!isHtml) {
+                    config['removeButtons'] = 'PasteFromWord,Paste,Bold,Italic,Underline,Strike,TextColor,Format,BGColor,Link,Image,Iframe,Unlink,Youtube,Embed'
+                }
+
+                CKEDITOR.inline($block.get(0), config)
                 break;
 
             case 'save':

--- a/js/visual/js/visual.js
+++ b/js/visual/js/visual.js
@@ -53,7 +53,7 @@ $(function () {
         var $this = $(this),
             id = $this.attr('id').substring(6),
             moveBtn = ($this.parent('.groupWrapper').hasClass('groupWrapper--movable')) ? '<div class="box-visual__actions__item box-visual__actions__item--move"><span class="v-icon v-icon--arrows"></span></div>' : '',
-            editBtn = (-1 !== ['html', 'plain'].indexOf($this.data('type'))) ? '<a class="js-block-inline-edit box-visual__actions__item box-visual__actions__item--edit" data-type="blocks" data-name="' + id + '" data-id="' + $this.data('block_id') + '" href="#" data-action="edit"><span class="v-icon v-icon--pencil"></span></a>' : '',
+            editBtn = (-1 !== ['html', 'plain'].indexOf($this.data('type'))) ? '<a class="js-block-inline-edit box-visual__actions__item box-visual__actions__item--edit" data-type="blocks" data-name="' + id + '" data-id="' + $this.data('block_id') + '" data-is_html="' + ($this.data('type') === 'html') + '" href="#" data-action="edit"><span class="v-icon v-icon--pencil"></span></a>' : '',
             hiddenClass = (1 == $this.attr('vm-hidden')) ? ' box-visual--hidden' : '';
 
         $this.addClass('box-visual ' + hiddenClass).append(
@@ -81,7 +81,8 @@ $(function () {
         var $this = $(this),
             $block = $this.closest('.box-visual').find('.box__content'),
             blockName = $this.data('name'),
-            blockId = $this.data('id');
+            blockId = $this.data('id'),
+            isHtml = $this.data('is_html');
 
         switch ($this.data('action')) {
             case 'edit':
@@ -95,8 +96,9 @@ $(function () {
                 $this.data('action', 'edit')
                 $this.find('.v-icon').removeClass('v-icon--check-circle-o').addClass('v-icon--pencil')
                 var editor = CKEDITOR['instances']['content_' + blockName]
+                var data = isHtml ? editor.getData() : editor.element.getText()
 
-                saveBlockInline(blockId, editor.getData());
+                saveBlockInline(blockId, data);
 
                 $block.removeAttr('contenteditable')
                 editor.destroy()

--- a/modules/blog/templates/admin/blog1.tpl
+++ b/modules/blog/templates/admin/blog1.tpl
@@ -52,7 +52,7 @@
 
                             <div class="caption">
                                 <a class="btn btn-small btn-danger js-cmd-delete-file" href="#"
-                                   title="{lang key='delete'}" data-file="{$item.image}" data-item="blog_entries"
+                                   title="{lang key='delete' readonly=true}" data-file="{$item.image}" data-item="blog_entries"
                                    data-field="image" data-id="{$id}"><i class="i-remove-sign"></i></a>
                             </div>
                         </div>

--- a/modules/blog/templates/front/index.tpl
+++ b/modules/blog/templates/front/index.tpl
@@ -70,9 +70,9 @@
                     </div>
                     <div class="ia-item__labels">
                         {if $member && $member.id == $blog_entry.member_id && 'active' != $blog_entry.status}
-                            <span class="label label-{$blog_entry.status}" title="{lang key=$blog_entry.status default=$blog_entry.status}"><span class="fa fa-warning"></span> {lang key=$blog_entry.status default=$blog_entry.status}</span>
+                            <span class="label label-{$blog_entry.status}" title="{lang key=$blog_entry.status default=$blog_entry.status readonly=true}"><span class="fa fa-warning"></span> {lang key=$blog_entry.status default=$blog_entry.status}</span>
                         {/if}
-                        {if $blog_entry.featured}<span class="label label-info" title="{lang key='featured'}"><span class="fa fa-star-o"></span> {lang key='featured'}</span>{/if}
+                        {if $blog_entry.featured}<span class="label label-info" title="{lang key='featured' readonly=true}"><span class="fa fa-star-o"></span> {lang key='featured'}</span>{/if}
                     </div>
                 </div>
 

--- a/templates/_common/block.filters.tpl
+++ b/templates/_common/block.filters.tpl
@@ -87,7 +87,7 @@
 
         {if $member}
             <div class="ia-form-filters__actions">
-                <a href="{$smarty.const.IA_URL}search/my/" class="btn btn-xs btn-success" data-loading-text="{lang key='loading'}" id="js-cmd-open-searches">{lang key='my_searches'}</a>
+                <a href="{$smarty.const.IA_URL}search/my/" class="btn btn-xs btn-success" data-loading-text="{lang key='loading' readonly=true}" id="js-cmd-open-searches">{lang key='my_searches'}</a>
                 <div class="modal fade" id="js-modal-searches" tabindex="-1" role="dialog">
                     <div class="modal-dialog" role="document"><div class="modal-content"></div></div>
                 </div>

--- a/templates/_common/favorites-button.tpl
+++ b/templates/_common/favorites-button.tpl
@@ -5,5 +5,5 @@
     data-guests="{$replace.guests}"
     data-text-add="<span class='fa fa-heart-o'></span>"
     data-text-delete="<span class='fa fa-heart'></span>"
-    rel="nofollow" title="{lang key=$replace.text}">
+    rel="nofollow" title="{lang key=$replace.text readonly=true}">
     {if 'add' == $replace.action}<span class='fa fa-heart-o'></span>{else}<span class='fa fa-heart'></span>{/if}</a>

--- a/templates/_common/field-type-content-manage.tpl
+++ b/templates/_common/field-type-content-manage.tpl
@@ -253,7 +253,7 @@ $(function() {
                 {if is_string($value)}{$value = unserialize($value)}{/if}
                 <div class="thumbnail">
                     <div class="thumbnail__actions">
-                        <button type="button" class="btn btn-danger btn-sm js-delete-file" data-item="{$field.item}" data-field="{$fieldName}" data-item-id="{$item.id|default:''}" data-file="{$value.file|escape}" title="{lang key='delete'}"><span class="fa fa-times"></span></button>
+                        <button type="button" class="btn btn-danger btn-sm js-delete-file" data-item="{$field.item}" data-field="{$fieldName}" data-item-id="{$item.id|default:''}" data-file="{$value.file|escape}" title="{lang key='delete' readonly=true}"><span class="fa fa-times"></span></button>
                     </div>
 
                     {if $field.thumb_width == $field.image_width && $field.thumb_height == $field.image_height}
@@ -290,18 +290,13 @@ $(function() {
                             <div class="thumbnail upload-items__item">
                                 <div class="btn-group thumbnail__actions">
                                     <span class="btn btn-default btn-sm drag-handle"><span class="fa fa-arrows"></span></span>
-                                    <button type="button" class="btn btn-sm btn-danger js-delete-file" data-item="{$field.item}" data-field="{$fieldName}" data-item-id="{$item.id|default:''}" data-file="{$entry.file}" title="{lang key='delete'}"><span class="fa fa-times"></span></button>
+                                    <button type="button" class="btn btn-sm btn-danger js-delete-file" data-item="{$field.item}" data-field="{$fieldName}" data-item-id="{$item.id|default:''}" data-file="{$entry.file}" title="{lang key='delete' readonly=true}"><span class="fa fa-times"></span></button>
                                 </div>
 
                                 <a class="thumbnail__image" href="{ia_image file=$entry field=$field url=true large=true}" rel="ia_lightbox[{$fieldName}]">
                                     {ia_image file=$entry field=$field class='img-responsive'}
                                 </a>
 
-                                {*<div class="caption">
-                                    <h5><a href="#" id="{$fieldName}_{$entry@index}" data-type="text" data-item="{$field.item}" data-field="{$fieldName}" data-item-id="{$item.id}" data-picture-path="{$entry.path}" data-pk="1" data-emptytext="{lang key='empty_image_title'}" class="js-edit-picture-title editable editable-click">{$entry.title|escape}</a></h5>
-                                </div>
-
-                                <input type="hidden" name="{$fieldName}[{$entry@index}][title]" value="{$entry.title|escape}">*}
                                 {foreach $entry as $k => $v}
                                 <input type="hidden" name="{$fieldName}[{$entry@index}][{$k}]" value="{$v|escape}">
                                 {/foreach}
@@ -356,7 +351,7 @@ $(function() {
                             <input type="hidden" name="{$fieldName}[{$entry@index}][path]" value="{$entry.path|escape}">
                             <input type="hidden" name="{$fieldName}[{$entry@index}][file]" value="{$entry.file|escape}">
                             <div class="input-group-btn">
-                                <a class="btn btn-default" href="{$core.page.nonProtocolUrl}uploads/{$entry.path}{$entry.file}" title="{lang key='download'}" download><span class="fa fa-cloud-download"></span> {lang key='download'}</a>
+                                <a class="btn btn-default" href="{$core.page.nonProtocolUrl}uploads/{$entry.path}{$entry.file}" title="{lang key='download' readonly=true}" download><span class="fa fa-cloud-download"></span> {lang key='download'}</a>
                                 <span class="btn btn-default drag-handle"><span class="fa fa-arrows-v"></span></span>
                                 <button type="button" class="btn btn-danger js-delete-file" data-item="{$field.item}" data-field="{$fieldName}" data-item-id="{$item.id|default:''}" data-file="{$entry.file|escape}">{lang key='delete'}</button>
                             </div>
@@ -382,7 +377,7 @@ $(function() {
                     </div>
                     <div class="col-md-6">
                         <div class="input-group">
-                            <input type="text" class="form-control" placeholder="{lang key='title'}" name="{$fieldName}_title[]" maxlength="100">
+                            <input type="text" class="form-control" placeholder="{lang key='title' readonly=true}" name="{$fieldName}_title[]" maxlength="100">
                             {if $max_num > 0}
                                 <div class="input-group-btn">
                                     <button type="button" class="js-add-img btn btn-default"><span class="fa fa-plus"></span></button>
@@ -527,7 +522,7 @@ $(function() {
             {/if}
         {/if}
 
-        {assign tooltip {lang key="field_tooltip_{$field.item}_{$field.name}" default=''}}
+        {assign tooltip {lang key="field_tooltip_{$field.item}_{$field.name}" default='' readonly=true}}
         {if $tooltip}<p class="help-block help-block--tooltip">{$tooltip|escape|nl2br}</p>{/if}
 </div>
 {if isset($field_after[$fieldName])}{$field_after.$fieldName}{/if}

--- a/templates/_common/ia-alpha-sorting.tpl
+++ b/templates/_common/ia-alpha-sorting.tpl
@@ -6,5 +6,5 @@
             <a href="{$url}{$letter}/" class="btn btn-sm btn-default">{$letter}</a>
         {/if}
     {/foreach}
-    <a href="{$url}" class="btn btn-sm btn-warning" title="{lang key='reset'}"><span class="fa fa-remove"></span></a>
+    <a href="{$url}" class="btn btn-sm btn-warning" title="{lang key='reset' readonly=true}"><span class="fa fa-remove"></span></a>
 </div>

--- a/templates/_common/my-searches.tpl
+++ b/templates/_common/my-searches.tpl
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <button type="button" class="close" data-dismiss="modal" aria-label="{lang key='close'}"><span aria-hidden="true">&times;</span></button>
+    <button type="button" class="close" data-dismiss="modal" aria-label="{lang key='close' readonly=true}"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">{lang key='my_saved_searches'}</h4>
 </div>
 <div class="modal-body">
@@ -8,10 +8,10 @@
             {foreach $searches as $entry}
                 <tr>
                     <td width="100"><small>{$entry.date|date_format:$core.config.date_format}</small></td>
-                    <td><a href="{$smarty.const.IA_URL}{$entry.params}" title="{lang key='open_in_new_tab'}" target="_blank">{$entry.title|escape|default:"<em>{lang key='untitled'}</em>"}</a></td>
+                    <td><a href="{$smarty.const.IA_URL}{$entry.params}" title="{lang key='open_in_new_tab' readonly=true}" target="_blank">{$entry.title|escape|default:"<em>{lang key='untitled'}</em>"}</a></td>
                     <td width="60"><small>{lang key=$entry.item}</small></td>
                     <td width="20">
-                        <a href="#" class="js-delete-search" data-id="{$entry.id}" title="{lang key='delete'}">
+                        <a href="#" class="js-delete-search" data-id="{$entry.id}" title="{lang key='delete' readonly=true}">
                             <span class="fa fa-remove"></span>
                         </a>
                     </td>

--- a/templates/_common/page.tpl
+++ b/templates/_common/page.tpl
@@ -3,10 +3,23 @@
         <div class="alert alert-warning">{$page_protect}</div>
     {/if}
 
-    {$content}
+    {if isset($manageMode)}
+        <div id="Blocks" class="groupWrapper">
+            <div class="box-visual">
+                <div id="page-content__{$core.page.name}"
+                     class="visual-page-content--wrapper">{$content}</div>
+                <div class="box-visual__actions">
+                    <a class="js-page-inline-edit box-visual__actions__item box-visual__actions__item--edit"
+                       data-type="pages" data-name="{$core.page.name}" href="#"
+                       data-action="edit"><span class="v-icon v-icon--pencil"></span></a>
+                </div>
+            </div>
+        </div>
+    {else}
+        {$content}
+    {/if}
 {else}
     <div class="alert alert-warning">{lang key='password_protected_page'}</div>
-
     <form action="{$smarty.const.IA_SELF}" method="post" class="form-inline">
         {preventCsrf}
         <label>{lang key='password'}:

--- a/templates/_common/pagination.tpl
+++ b/templates/_common/pagination.tpl
@@ -1,8 +1,8 @@
 <ul class="pagination">
     <li><span>{lang key='page'} {$_pagination.current_page} / {$_pagination.pages_count}</span></li>
     {if $_pagination.current_page > 1}
-        <li><a href="{$_pagination.first_page}" title="{lang key='first'}" rel="first" data-page="1"><span class="fa fa-angle-double-left"></span></a></li>
-        <li><a href="{$_pagination.pages_range[$_pagination.current_page-1]}" title="{lang key='previous'}" rel="prev" data-page="{$_pagination.current_page-1}"><span class="fa fa-angle-left"></span></a></li>
+        <li><a href="{$_pagination.first_page}" title="{lang key='first' readonly=true}" rel="first" data-page="1"><span class="fa fa-angle-double-left"></span></a></li>
+        <li><a href="{$_pagination.pages_range[$_pagination.current_page-1]}" title="{lang key='previous' readonly=true}" rel="prev" data-page="{$_pagination.current_page-1}"><span class="fa fa-angle-left"></span></a></li>
     {/if}
     {foreach $_pagination.pages_range as $pageNumber => $url}
         {if $pageNumber != $_pagination.current_page}
@@ -12,7 +12,7 @@
         {/if}
     {/foreach}
     {if $_pagination.current_page < $_pagination.pages_count}
-        <li><a href="{$_pagination.pages_range[$_pagination.current_page+1]}" rel="next" title="{lang key='next'}" data-page="{$_pagination.current_page+1}"><span class="fa fa-angle-right"></span></a></li>
-        <li><a href="{$_pagination.last_page}" title="{lang key='last'}" rel="last" data-page="{$_pagination.pages_count}"><span class="fa fa-angle-double-right"></span></a></li>
+        <li><a href="{$_pagination.pages_range[$_pagination.current_page+1]}" rel="next" title="{lang key='next' readonly=true}" data-page="{$_pagination.current_page+1}"><span class="fa fa-angle-right"></span></a></li>
+        <li><a href="{$_pagination.last_page}" title="{lang key='last' readonly=true}" rel="last" data-page="{$_pagination.pages_count}"><span class="fa fa-angle-double-right"></span></a></li>
     {/if}
 </ul>

--- a/templates/_common/render-blocks.tpl
+++ b/templates/_common/render-blocks.tpl
@@ -1,7 +1,7 @@
 {if isset($iaPositions) && !$iaPositions[$position]['menu']}<div id="{$position}Blocks" class="groupWrapper{if $iaPositions[$position]['movable']} groupWrapper--movable{/if}{if $iaPositions[$position]['hidden']} groupWrapper--hidden{/if}">{/if}
 
-{foreach $blocks as $block}
-    {ia_block title=$block.title name=$block.name header=$block.header collapsible=$block.collapsible collapsed=$block.collapsed tpl=$block.tpl classname=$block.classname hidden=$block.hidden}
+    {foreach $blocks as $block}
+    {ia_block title=$block.title name=$block.name header=$block.header collapsible=$block.collapsible collapsed=$block.collapsed tpl=$block.tpl classname=$block.classname hidden=$block.hidden type=$block.type}
         {ia_block_view block=$block}
     {/ia_block}
 {/foreach}

--- a/templates/_common/render-blocks.tpl
+++ b/templates/_common/render-blocks.tpl
@@ -1,7 +1,17 @@
 {if isset($iaPositions) && !$iaPositions[$position]['menu']}<div id="{$position}Blocks" class="groupWrapper{if $iaPositions[$position]['movable']} groupWrapper--movable{/if}{if $iaPositions[$position]['hidden']} groupWrapper--hidden{/if}">{/if}
 
     {foreach $blocks as $block}
-    {ia_block title=$block.title name=$block.name header=$block.header collapsible=$block.collapsible collapsed=$block.collapsed tpl=$block.tpl classname=$block.classname hidden=$block.hidden type=$block.type}
+    {ia_block
+        title=$block.title
+        name=$block.name
+        header=$block.header
+        collapsible=$block.collapsible
+        collapsed=$block.collapsed
+        tpl=$block.tpl
+        classname=$block.classname
+        hidden=$block.hidden
+        type=$block.type
+        id=$block.id}
         {ia_block_view block=$block}
     {/ia_block}
 {/foreach}

--- a/templates/_common/search.tpl
+++ b/templates/_common/search.tpl
@@ -1,7 +1,7 @@
 {if $query || $regular}
     <form class="ia-form">
         <div class="input-group">
-            <input type="text" class="form-control" name="q" id="input-search-query" placeholder="{lang key='search_for'}" value="{$query|escape}">
+            <input type="text" class="form-control" name="q" id="input-search-query" placeholder="{lang key='search_for' readonly=true}" value="{$query|escape}">
             <span class="input-group-btn">
                 <button class="btn btn-primary" type="submit">{lang key='search'}</button>
             </span>

--- a/templates/_common/tree.tpl
+++ b/templates/_common/tree.tpl
@@ -5,7 +5,7 @@
         <a href="#" class="categories-toggle js-tree-toggler">{lang key='open_close'}</a>
         {if $search}
             <div id="js-tree-search"{if iaCore::ACTION_EDIT == $pageAction} style="display:none"{/if}>
-                <input class="form-control" type="text" placeholder="{lang key='start_typing_to_filter'}">
+                <input class="form-control" type="text" placeholder="{lang key='start_typing_to_filter' readonly=true}">
             </div>
         {/if}
         <div id="{$tree.selector|default:'js-tree'}" class="tree categories-tree">{lang key='loading'}</div>

--- a/templates/_common/view-member.tpl
+++ b/templates/_common/view-member.tpl
@@ -4,8 +4,8 @@
 
         {if $item.featured || $item.sponsored}
             <div class="ia-item__labels">
-                {if $item.sponsored}<span class="label label-warning" title="{lang key='sponsored'}"><span class="fa fa-star"></span> {lang key='sponsored'}</span>{/if}{* 866 *}
-                {if $item.featured}<span class="label label-info" title="{lang key='featured'}"><span class="fa fa-star-o"></span> {lang key='featured'}</span>{/if}{* 866 *}
+                {if $item.sponsored}<span class="label label-warning" title="{lang key='sponsored' readonly=true}"><span class="fa fa-star"></span> {lang key='sponsored'}</span>{/if}
+                {if $item.featured}<span class="label label-info" title="{lang key='featured' readonly=true}"><span class="fa fa-star-o"></span> {lang key='featured'}</span>{/if}
             </div>
         {/if}
     </div>

--- a/templates/_common/view-member.tpl
+++ b/templates/_common/view-member.tpl
@@ -4,8 +4,8 @@
 
         {if $item.featured || $item.sponsored}
             <div class="ia-item__labels">
-                {if $item.sponsored}<span class="label label-warning" title="{lang key='sponsored'}"><span class="fa fa-star"></span> {lang key='sponsored'}</span>{/if}
-                {if $item.featured}<span class="label label-info" title="{lang key='featured'}"><span class="fa fa-star-o"></span> {lang key='featured'}</span>{/if}
+                {if $item.sponsored}<span class="label label-warning" title="{lang key='sponsored'}"><span class="fa fa-star"></span> {lang key='sponsored'}</span>{/if}{* 866 *}
+                {if $item.featured}<span class="label label-info" title="{lang key='featured'}"><span class="fa fa-star-o"></span> {lang key='featured'}</span>{/if}{* 866 *}
             </div>
         {/if}
     </div>

--- a/templates/_common/visual-mode.tpl
+++ b/templates/_common/visual-mode.tpl
@@ -109,3 +109,5 @@
         *}
     </div>
 </div>
+
+{ia_print_js files='ckeditor/ckeditor'}

--- a/templates/_common/visual-mode.tpl
+++ b/templates/_common/visual-mode.tpl
@@ -6,7 +6,7 @@
 
 <div class="sb-slide vm-bar">
     <div class="vm-bar__title">Visual mode</div>
-    <a class="vm-bar__exit" href="?manage_exit=y" title="{lang key='exit'}"><span class="v-icon v-icon--exit"></span> {lang key='exit'}</a>
+    <a class="vm-bar__exit" href="?manage_exit=y" title="{lang key='exit' readonly=true}"><span class="v-icon v-icon--exit"></span> {lang key='exit' readonly=true}</a>
 </div>
 
 <div class="sb-slidebar sb-left">

--- a/templates/_common/visual-mode.tpl
+++ b/templates/_common/visual-mode.tpl
@@ -6,7 +6,7 @@
 
 <div class="sb-slide vm-bar">
     <div class="vm-bar__title">Visual mode</div>
-    <a class="vm-bar__exit" href="?manage_exit=y" title="{lang key='exit' readonly=true}"><span class="v-icon v-icon--exit"></span> {lang key='exit' readonly=true}</a>
+    <a class="vm-bar__exit" href="?manage_exit=y" title="{lang key='exit' readonly=true}"><span class="v-icon v-icon--exit"></span> {lang key='exit'}</a>
 </div>
 
 <div class="sb-slidebar sb-left">

--- a/templates/kickstart/block.tpl
+++ b/templates/kickstart/block.tpl
@@ -2,7 +2,7 @@
 {if $header}
     <div id="block_{$name}"
          class="box {$classname}{if isset($collapsible) && $collapsible} collapsible{if isset($collapsed) && $collapsed} collapsed{/if}{/if}"
-        {if isset($manageMode)} vm-hidden="{$hidden}" data-type="{$type}"{/if}>
+        {if isset($manageMode)} vm-hidden="{$hidden}" data-type="{$type}" data-block_id="{$id}"{/if}>
         {if isset($position) && 'landing' == $position}
             <div class="container">
         {/if}
@@ -18,7 +18,7 @@
         <div id="content_{$name}" class="box__content"{if isset($display) && !$display} style="display: none;"{/if}>
 {else}
     <div id="block_{$name}" class="box box--no-header {$classname}"
-        {if isset($manageMode)} vm-hidden="{$hidden}" data-type="{$type}"{/if}>
+        {if isset($manageMode)} vm-hidden="{$hidden}" data-type="{$type}" data-block_id="{$id}"{/if}>
         {if isset($position) && 'landing' == $position}
             <div class="container">
         {/if}

--- a/templates/kickstart/block.tpl
+++ b/templates/kickstart/block.tpl
@@ -25,7 +25,11 @@
 {/if}
 
 <!--__b_c_{$id}-->
+{if isset($manageMode) && ($type === 'plain' || empty($header))}
+<div>{$_block_content_}</div>
+{else}
 {$_block_content_}
+{/if}
 <!--__e_c_{$id}-->
 
 {if $header}

--- a/templates/kickstart/block.tpl
+++ b/templates/kickstart/block.tpl
@@ -1,7 +1,8 @@
 <!--__b_{$id}-->
 {if $header}
     <div id="block_{$name}"
-         class="box {$classname}{if isset($collapsible) && $collapsible} collapsible{if isset($collapsed) && $collapsed} collapsed{/if}{/if}" {if isset($manageMode)} vm-hidden="{$hidden}"{/if}>
+         class="box {$classname}{if isset($collapsible) && $collapsible} collapsible{if isset($collapsed) && $collapsed} collapsed{/if}{/if}"
+        {if isset($manageMode)} vm-hidden="{$hidden}" data-type="{$type}"{/if}>
         {if isset($position) && 'landing' == $position}
             <div class="container">
         {/if}
@@ -16,7 +17,8 @@
         </h4>
         <div id="content_{$name}" class="box__content"{if isset($display) && !$display} style="display: none;"{/if}>
 {else}
-    <div id="block_{$name}" class="box box--no-header {$classname}"{if isset($manageMode)} vm-hidden="{$hidden}"{/if}>
+    <div id="block_{$name}" class="box box--no-header {$classname}"
+        {if isset($manageMode)} vm-hidden="{$hidden}" data-type="{$type}"{/if}>
         {if isset($position) && 'landing' == $position}
             <div class="container">
         {/if}

--- a/templates/kickstart/layout.tpl
+++ b/templates/kickstart/layout.tpl
@@ -105,7 +105,7 @@
                 {/if}
                 {if $core.config.search_inventory}
                     <form method="get" action="{$smarty.const.IA_URL}search/" class="search-inventory pull-right">
-                        <input type="text" name="q" placeholder="{lang key='search'}">
+                        <input type="text" name="q" placeholder="{lang key='search' readonly=true}">
                         <button type="submit"><span class="fa fa-search"></span></button>
                     </form>
                 {/if}
@@ -142,7 +142,7 @@
                         <form method="get" action="{$smarty.const.IA_URL}search/" class="search-navbar pull-right">
                             <button class="search-navbar__toggle js-search-navbar-toggle" type="button"><span class="fa fa-search"></span></button>
                             <div class="input-group">
-                                <input type="text" name="q" class="form-control" placeholder="{lang key='search'}">
+                                <input type="text" name="q" class="form-control" placeholder="{lang key='search' readonly=true}">
                                 <div class="input-group-btn">
                                     <button class="btn btn-primary" type="submit">{lang key='search'}</button>
                                 </div>

--- a/templates/kickstart/login.tpl
+++ b/templates/kickstart/login.tpl
@@ -6,12 +6,12 @@
             <div class="form-group">
                 <input class="form-control input-lg" type="text" name="username"
                        value="{if isset($smarty.post.username)}{$smarty.post.username|escape}{/if}"
-                       placeholder="{lang key='username_or_email'}">
+                       placeholder="{lang key='username_or_email' readonly=true}">
             </div>
 
             <div class="form-group">
                 <input class="form-control input-lg" type="password" name="password"
-                       placeholder="{lang key='password'}">
+                       placeholder="{lang key='password' readonly=true}">
             </div>
 
             <div class="form-group">

--- a/templates/kickstart/profile.tpl
+++ b/templates/kickstart/profile.tpl
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-md-3">
             <div class="ia-item-author">
-                <a href="{$smarty.const.IA_URL}profile/?edit" class="btn btn-default btn-sm ia-item-author__edit" title="{lang key='edit'}"><span class="fa fa-pencil"></span></a>
+                <a href="{$smarty.const.IA_URL}profile/?edit" class="btn btn-default btn-sm ia-item-author__edit" title="{lang key='edit' readonly=true}"><span class="fa fa-pencil"></span></a>
                 <a class="ia-item-author__image" href="{ia_url type='url' item='member' data=$member}">
                     {ia_image file=$member.avatar type='thumbnail' width=120 alt=$member.fullname|default:$member.username gravatar=true email=$member.email}
                 </a>

--- a/templates/kickstart/render-menu.tpl
+++ b/templates/kickstart/render-menu.tpl
@@ -15,7 +15,7 @@
                 {ia_menu menus=$menu.contents class='dropdown-menu' loginout=true}
             </li>
             {access object='admin_access'}
-                <li><a rel="nofollow" href="{$smarty.const.IA_ADMIN_URL}" target="_blank" title="{lang key='admin_dashboard'}"><span class="fa fa-cog"></span><span class="visible-xs-inline"> {lang key='admin_dashboard'}</span></a></li>
+                <li><a rel="nofollow" href="{$smarty.const.IA_ADMIN_URL}" target="_blank" title="{lang key='admin_dashboard' readonly=true}"><span class="fa fa-cog"></span><span class="visible-xs-inline"> {lang key='admin_dashboard' readonly=true}</span></a></li>
             {/access}
         </ul>
     {else}


### PR DESCRIPTION
Block inline editing:
![image](https://user-images.githubusercontent.com/7892851/75991876-cac80900-5eff-11ea-952a-03b6283d94fb.png)
![image](https://user-images.githubusercontent.com/7892851/75991891-d3b8da80-5eff-11ea-921b-d1ff1631e71c.png)

Phrase editor:
![image](https://user-images.githubusercontent.com/7892851/75991929-e59a7d80-5eff-11ea-89ba-25e35f7a7284.png)

Phrase editor (plain text):
![image](https://user-images.githubusercontent.com/7892851/75992008-0367e280-5f00-11ea-9d62-b116e245e314.png)

Some minor CSS tweaks should be done, but in general, functionality is complete.

Editable blocks: HTML & plain. Smarty blocks cannot be edited inline on the frontend as they are rendered on server side.

Simple pages like about, privacy, etc. can be edited as it is shown in the screenshots.

Phrases WITH NO PLACEHOLDERS can be edited also. For "bare text" phrases simple editor is enabled with no ability to insert HTML tags. For phrases that include some tags rich text editor is enabled with possibility to insert some basic tags.